### PR TITLE
Potential fix for code scanning alert no. 3: Artifact poisoning

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -14,11 +14,13 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Create temporary directory for artifacts
+        run: mkdir -p ${{ runner.temp }}/artifacts
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
-          path: ./artifacts
+          path: ${{ runner.temp }}/artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }} 
           merge-multiple: true
       
@@ -36,7 +38,11 @@ jobs:
 
       - name: Load tag name
         run: |
-          TAG_NAME=$(cat ./artifacts/tag_name.txt)
+          TAG_NAME=$(cat ${{ runner.temp }}/artifacts/tag_name.txt)
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Invalid tag name: $TAG_NAME"
+            exit 1
+          fi
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
           echo "TAG_VERSION=${TAG_NAME#v}" >> $GITHUB_ENV
 
@@ -50,7 +56,11 @@ jobs:
 
       - name: Load upload URL
         run: |
-          UPLOAD_URL=$(cat ./artifacts/upload_url.txt)
+          UPLOAD_URL=$(cat ${{ runner.temp }}/artifacts/upload_url.txt)
+          if [[ ! "$UPLOAD_URL" =~ ^https://.* ]]; then
+            echo "❌ Invalid upload URL: $UPLOAD_URL"
+            exit 1
+          fi
           echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
 
       - name: Checkout source for tag


### PR DESCRIPTION
Potential fix for [https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3](https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3)

To fix the issue, the workflow should treat all downloaded artifacts as untrusted and verify their contents before using them. Specifically:
1. Extract artifacts to a temporary directory to prevent overwriting existing files.
2. Validate the contents of the artifacts (e.g., ensure `tag_name.txt` contains a valid tag name and `upload_url.txt` contains a valid URL) before using them in subsequent steps.
3. Avoid directly executing commands that depend on unverified artifact data.

The changes will be made in `.github/workflows/native-build.yml`:
- Modify the artifact download steps to extract artifacts into a temporary directory.
- Add validation steps to verify the contents of `tag_name.txt` and `upload_url.txt`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
