### PR TITLE
Potential fix for code scanning alert no. 7: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Load upload URL
         run: |
-          UPLOAD_URL=$(cat ./artifacts/upload_url.txt)
+          UPLOAD_URL=$(cat ./artifacts/upload_url.txt | tr -d '\n\r')
           echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
 
       - name: Checkout source for tag


### PR DESCRIPTION
Potential fix for [https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/7](https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/7)

To fix this problem, we must sanitize the contents of `upload_url.txt` before assigning it to the `UPLOAD_URL` environment variable. The best practice is to remove any newlines and other potentially dangerous characters that could allow an attacker to inject additional environment variables. For a URL, we can safely strip newlines and carriage returns, and optionally validate that the value matches a URL pattern. The fix should be applied in the step that loads the upload URL (lines 52-55). Specifically, we should replace the direct assignment with a sanitized version, e.g., by using `tr -d '\n\r'` to remove newlines and carriage returns. Optionally, we could also use a regular expression to ensure the value is a valid URL, but at minimum, removing newlines is required.

No new imports or dependencies are needed, as standard shell utilities (`tr`) are available in the GitHub Actions runner environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
