### PR TITLE
Potential fix for code scanning alert no. 3: Artifact poisoning

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -27,13 +27,13 @@ jobs:
       - name: List contents of artifacts
         run: |
           echo "Listing contents of downloaded artifacts:"
-          ls -R ./artifacts    
+          ls -R ${{ runner.temp }}/artifacts
       - name: Download tag-name artifact
         uses: actions/download-artifact@v4
         with:
           name: tag-name
           run-id: ${{ github.event.workflow_run.id }}
-          path: ./artifacts
+          path: ${{ runner.temp }}/artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Load tag name
@@ -51,7 +51,7 @@ jobs:
         with:
           name: upload-url
           run-id: ${{ github.event.workflow_run.id }}
-          path: ./artifacts
+          path: ${{ runner.temp }}/artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Load upload URL


### PR DESCRIPTION
Potential fix for [https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3](https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3)

To fix the artifact poisoning risk, we need to ensure that all artifact contents are treated as untrusted and cannot override files in the repository workspace. The workflow already extracts artifacts to a temporary directory (`${{ runner.temp }}/artifacts`), which is good. However, there are two issues to address:

1. **Consistency:** All artifact downloads should use the same temporary directory (`${{ runner.temp }}/artifacts`) as the extraction path, not `./artifacts` (which is in the workspace and could override files).
2. **Validation:** The workflow should ensure that only the expected files are present in the artifacts directory, and that their contents are strictly validated before use.

The main fix is to change the `path` for all `actions/download-artifact` steps to use `${{ runner.temp }}/artifacts` instead of `./artifacts`. Additionally, the `ls` command that lists artifact contents should point to the correct directory. This ensures that no files in the workspace can be overwritten by artifacts.

**Files/regions to change:**
- In `.github/workflows/native-build.yml`, update all `actions/download-artifact` steps to use `path: ${{ runner.temp }}/artifacts`.
- Update the `ls` command in the "List contents of artifacts" step to use the correct path.

No new methods or imports are needed; only the YAML workflow file needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
