### PR TITLE
Potential fix for code scanning alert no. 3: Artifact poisoning

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -24,10 +24,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }} 
           merge-multiple: true
       
-      - name: List contents of artifacts
+      - name: Verify artifact integrity
         run: |
-          echo "Listing contents of downloaded artifacts:"
-          ls -R ${{ runner.temp }}/artifacts
+          echo "Verifying checksums of downloaded artifacts..."
+          echo "Expected checksum for tag_name.txt: ${{ secrets.TAG_NAME_CHECKSUM }}"
+          echo "Expected checksum for upload_url.txt: ${{ secrets.UPLOAD_URL_CHECKSUM }}"
+          echo "Computing checksum for tag_name.txt..."
+          TAG_NAME_CHECKSUM=$(sha256sum ${{ runner.temp }}/artifacts/tag_name.txt | awk '{print $1}')
+          if [[ "$TAG_NAME_CHECKSUM" != "${{ secrets.TAG_NAME_CHECKSUM }}" ]]; then
+            echo "❌ Checksum mismatch for tag_name.txt"
+            exit 1
+          fi
+          echo "Computing checksum for upload_url.txt..."
+          UPLOAD_URL_CHECKSUM=$(sha256sum ${{ runner.temp }}/artifacts/upload_url.txt | awk '{print $1}')
+          if [[ "$UPLOAD_URL_CHECKSUM" != "${{ secrets.UPLOAD_URL_CHECKSUM }}" ]]; then
+            echo "❌ Checksum mismatch for upload_url.txt"
+            exit 1
+          fi
+          echo "✅ All checksums match. Artifacts are verified."
       - name: Download tag-name artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3](https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3)

To fix the issue, we need to ensure that all downloaded artifacts are verified before they are used. This can be achieved by implementing checksum verification for the artifacts. The workflow should include a step to compute and compare the checksum of each artifact against a trusted value. If the checksum does not match, the workflow should terminate with an error. This approach ensures that only trusted artifacts are used in subsequent steps.

Specifically:
1. Add a step to compute the checksum of each downloaded artifact.
2. Compare the computed checksum with a precomputed, trusted checksum value stored securely (e.g., in repository secrets or as part of the workflow configuration).
3. Terminate the workflow if any checksum does not match.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
