### PR TITLE
Potential fix for code scanning alert no. 3: Artifact poisoning

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -29,6 +29,7 @@ jobs:
           echo "Verifying checksums of downloaded artifacts..."
           echo "Expected checksum for tag_name.txt: ${{ secrets.TAG_NAME_CHECKSUM }}"
           echo "Expected checksum for upload_url.txt: ${{ secrets.UPLOAD_URL_CHECKSUM }}"
+          echo "Expected checksum for additional_artifact.txt: ${{ secrets.ADDITIONAL_ARTIFACT_CHECKSUM }}"
           echo "Computing checksum for tag_name.txt..."
           TAG_NAME_CHECKSUM=$(sha256sum ${{ runner.temp }}/artifacts/tag_name.txt | awk '{print $1}')
           if [[ "$TAG_NAME_CHECKSUM" != "${{ secrets.TAG_NAME_CHECKSUM }}" ]]; then
@@ -39,6 +40,12 @@ jobs:
           UPLOAD_URL_CHECKSUM=$(sha256sum ${{ runner.temp }}/artifacts/upload_url.txt | awk '{print $1}')
           if [[ "$UPLOAD_URL_CHECKSUM" != "${{ secrets.UPLOAD_URL_CHECKSUM }}" ]]; then
             echo "❌ Checksum mismatch for upload_url.txt"
+            exit 1
+          fi
+          echo "Computing checksum for additional_artifact.txt..."
+          ADDITIONAL_ARTIFACT_CHECKSUM=$(sha256sum ${{ runner.temp }}/artifacts/additional_artifact.txt | awk '{print $1}')
+          if [[ "$ADDITIONAL_ARTIFACT_CHECKSUM" != "${{ secrets.ADDITIONAL_ARTIFACT_CHECKSUM }}" ]]; then
+            echo "❌ Checksum mismatch for additional_artifact.txt"
             exit 1
           fi
           echo "✅ All checksums match. Artifacts are verified."


### PR DESCRIPTION
Potential fix for [https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3](https://github.com/vshanbha/graalpy-sentiment/security/code-scanning/3)

To fix the issue, we need to ensure that all downloaded artifacts are verified for integrity before they are used in the build process. This can be achieved by:

1. Computing and storing checksums (e.g., SHA-256) for all artifacts during their creation in the upstream workflow.
2. Passing these checksums securely (e.g., via secrets or environment variables) to the current workflow.
3. Verifying the checksums of all downloaded artifacts against the expected values before proceeding with the build.

The fix involves adding checksum verification for all artifacts used in the `mvn` command. This ensures that only trusted artifacts are used, mitigating the risk of artifact poisoning.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
